### PR TITLE
cmake: add version to output name when available

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -199,6 +199,10 @@ ELSE()
   ENDIF()
 ENDIF()
 
+find_package (Git)
+if (!GIT_FOUND)
+  message (STATUS "GIT not found")
+endif ()
 add_subdirectory("TIVTC")
 add_subdirectory("TDeint")
 

--- a/src/TDeint/CMakeLists.txt
+++ b/src/TDeint/CMakeLists.txt
@@ -18,7 +18,20 @@ Include("Files.cmake")
 
 add_library(${PluginName} SHARED ${TDeint_Sources})
 
-set_target_properties(${PluginName} PROPERTIES "OUTPUT_NAME" "${PluginName}")
+if (GIT_FOUND)
+    execute_process (COMMAND ${GIT_EXECUTABLE} describe --tags --abbrev=0
+        OUTPUT_VARIABLE ver
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+    if (ver STREQUAL "")
+      set_target_properties(${PluginName} PROPERTIES OUTPUT_NAME "${PluginName}")
+    else ()
+      set_target_properties(${PluginName} PROPERTIES OUTPUT_NAME "${PluginName}.${ver}")
+    endif()
+else ()
+    set_target_properties(${PluginName} PROPERTIES OUTPUT_NAME "${PluginName}")
+endif ()
+
 if (MINGW)
   set_target_properties(${PluginName} PROPERTIES PREFIX "")
   set_target_properties(${PluginName} PROPERTIES IMPORT_PREFIX "")

--- a/src/TIVTC/CMakeLists.txt
+++ b/src/TIVTC/CMakeLists.txt
@@ -18,7 +18,20 @@ Include("Files.cmake")
 
 add_library(${PluginName} SHARED ${TIVTC_Sources})
 
-set_target_properties(${PluginName} PROPERTIES "OUTPUT_NAME" "${PluginName}")
+if (GIT_FOUND)
+    execute_process (COMMAND ${GIT_EXECUTABLE} describe --tags --abbrev=0
+        OUTPUT_VARIABLE ver
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+    if (ver STREQUAL "")
+      set_target_properties(${PluginName} PROPERTIES OUTPUT_NAME "${PluginName}")
+    else ()
+      set_target_properties(${PluginName} PROPERTIES OUTPUT_NAME "${PluginName}.${ver}")
+    endif()
+else ()
+    set_target_properties(${PluginName} PROPERTIES OUTPUT_NAME "${PluginName}")
+endif ()
+
 if (MINGW)
   set_target_properties(${PluginName} PROPERTIES PREFIX "")
   set_target_properties(${PluginName} PROPERTIES IMPORT_PREFIX "")


### PR DESCRIPTION
I find it quite useful to have the version added to the output name when switching between versions for testing.