### PR TITLE
Add frame property "TDecimateCycleMetrics"

### DIFF
--- a/Doc_TIVTC/TDecimate - READ ME.txt
+++ b/Doc_TIVTC/TDecimate - READ ME.txt
@@ -851,6 +851,35 @@ G.) FRAME PROPERTY SUPPORT
       Frame properties set by TFM: TFMMatch, _Combed, TFMD2VFilm, TFMField, TFMMics, TFMPP
       Frame properties read by TFM and TDecimate: TFMMatch, TFMD2VFilm, TFMField
       Frame properties read by TFMPP: TFMField, _Combed
+      
+      Frame properties set by TDecimate:  
+         TDecimateCycleMetrics (float array): normalised metrics for all frames in current cycle
+         TDecimateCycleMetricsPrev: same as TDecimateCycleMetrics but for previous cycle
+	 TDecimateCycleMetricsNext: same as TDecimateCycleMetrics but for next cycle
+         TDecimateCycleFrameNums (int array): frame numbers corresponding to TDecimateCycleMetrics	   
+	 TDecimateCycleFrameNumsPrev: same as TDecimateCycleFrameNums but for previous cycle     
+	 TDecimateCycleFrameNumsNext: same as TDecimateCycleFrameNums but for next cycle  
+	 TDecimateCycleBlendStatus (integer): indicates if frames in the current cycle are blended:
+	     -20=undefined, 0=not blended, 1=blended, 2=not blended due to scenechange, 3=not blended due to 2 dup cycle workaround
+		  
+	 Example usage:	    
+           ScriptClip("PrintProps(last, current_frame)", after_frame=true, local=false)
+	   function PrintProps(clip c, int current_frame){
+				
+	      metrics = propGetAsArray(c, "TDecimateCycleMetrics")
+	      fnums = propGetAsArray(c, "TDecimateCycleFrameNums")
+	      blendStatus = propGetAny(c, "TDecimateCycleBlendStatus")
+				
+	      string = ""
+	      for (i=0, ArraySize(metrics)-1){		
+		 string = string + "Frame " + String(fnums[i]) + ": " + String(metrics[i], "%0.2f") + "\n" 
+              }
+					
+	      string = string + "Blend status: " + String(blendStatus) + "\n"
+				
+	      c.Text(string, lsp=0, align=7, size=20, bold=true)
+ 	   }
+
       Frame properties read by TDecimate creation: TFMPP (but if Avisynth variable "TFMPPValue" exists then the variable has priority over it)
       Frame properties never read: TFMMics
       Traditionally, TFM is using a 32 bit "hint" encoded in the lsb bits of the first 32 pixels of a frame.

--- a/src/TIVTC/Cycle.h
+++ b/src/TIVTC/Cycle.h
@@ -79,6 +79,7 @@ public:
   int frameEO;	// frame + cycleE
   int type;		// video or film and how
   double *diffMetricsN;			// normalized metrics
+  int64_t* diffMetricsF = nullptr;   // frame numbers of normalized metrics
   uint64_t *diffMetricsU;	// unnormalized metrics
   uint64_t *diffMetricsUF;	// frame metrics (scenechange detection)
   uint64_t *tArray;			// used as temp storage when sorting

--- a/src/TIVTC/TDecimate.cpp
+++ b/src/TIVTC/TDecimate.cpp
@@ -58,17 +58,20 @@ PVideoFrame __stdcall TDecimate::GetFrame(int n, IScriptEnvironment *env)
           env->MakeWritable(&dst);     
       AVSMap* props = env->getFramePropsRW(dst); 
 
-      // curr cycle
+       // current cycle metrics, frame nums and blend status
       if (curr.diffMetricsF == nullptr) { curr.diffMetricsF = (int64_t*)malloc(curr.length * sizeof(int64_t)); }
       for (int i = 0; i < curr.length; ++i) { curr.diffMetricsF[i] = (int64_t)curr.frame + i; }
       env->propSetIntArray(props, PROP_TDecimateCycleFrameNums, curr.diffMetricsF, curr.length);
       env->propSetFloatArray(props, PROP_TDecimateCycleMetrics, curr.diffMetricsN, curr.length);
-      // prev cycle
+      env->propSetInt(props, PROP_TDecimateCycleBlendStatus, curr.blend, AVSPropAppendMode::PROPAPPENDMODE_REPLACE);
+      
+       // previous cycle metrics & frame nums
       if (prev.diffMetricsF == nullptr) { prev.diffMetricsF = (int64_t*)malloc(prev.length * sizeof(int64_t)); }
       for (int i = 0; i < prev.length; ++i) { prev.diffMetricsF[i] = (int64_t)prev.frame + i; }
       env->propSetIntArray(props, PROP_TDecimateCycleFrameNumsPrev, prev.diffMetricsF, prev.length);
       env->propSetFloatArray(props, PROP_TDecimateCycleMetricsPrev, prev.diffMetricsN, prev.length);
-      // next cycle
+      
+       // next cycle metrics & frame nums
       if (next.diffMetricsF == nullptr) { next.diffMetricsF = (int64_t*)malloc(next.length * sizeof(int64_t)); }
       for (int i = 0; i < next.length; ++i) { next.diffMetricsF[i] = (int64_t)next.frame + i; }
       env->propSetIntArray(props, PROP_TDecimateCycleFrameNumsNext, next.diffMetricsF, next.length);

--- a/src/TIVTC/TDecimate.cpp
+++ b/src/TIVTC/TDecimate.cpp
@@ -3746,6 +3746,10 @@ TDecimate::TDecimate(PClip _child, int _mode, int _cycleR, int _cycle, double _r
 
 TDecimate::~TDecimate()
 {
+  if (curr.diffMetricsF != nullptr) { free(curr.diffMetricsF); curr.diffMetricsF = nullptr; }
+  if (prev.diffMetricsF != nullptr) { free(prev.diffMetricsF); prev.diffMetricsF = nullptr; }
+  if (next.diffMetricsF != nullptr) { free(next.diffMetricsF); next.diffMetricsF = nullptr; }
+ 
   if (metricsOutArray.size())
   {
     if (output.size())

--- a/src/TIVTC/TDecimate.cpp
+++ b/src/TIVTC/TDecimate.cpp
@@ -57,11 +57,22 @@ PVideoFrame __stdcall TDecimate::GetFrame(int n, IScriptEnvironment *env)
       else
           env->MakeWritable(&dst);     
       AVSMap* props = env->getFramePropsRW(dst); 
- 
+
+      // curr cycle
       if (curr.diffMetricsF == nullptr) { curr.diffMetricsF = (int64_t*)malloc(curr.length * sizeof(int64_t)); }
       for (int i = 0; i < curr.length; ++i) { curr.diffMetricsF[i] = (int64_t)curr.frame + i; }
       env->propSetIntArray(props, PROP_TDecimateCycleFrameNums, curr.diffMetricsF, curr.length);
       env->propSetFloatArray(props, PROP_TDecimateCycleMetrics, curr.diffMetricsN, curr.length);
+      // prev cycle
+      if (prev.diffMetricsF == nullptr) { prev.diffMetricsF = (int64_t*)malloc(prev.length * sizeof(int64_t)); }
+      for (int i = 0; i < prev.length; ++i) { prev.diffMetricsF[i] = (int64_t)prev.frame + i; }
+      env->propSetIntArray(props, PROP_TDecimateCycleFrameNumsPrev, prev.diffMetricsF, prev.length);
+      env->propSetFloatArray(props, PROP_TDecimateCycleMetricsPrev, prev.diffMetricsN, prev.length);
+      // next cycle
+      if (next.diffMetricsF == nullptr) { next.diffMetricsF = (int64_t*)malloc(next.length * sizeof(int64_t)); }
+      for (int i = 0; i < next.length; ++i) { next.diffMetricsF[i] = (int64_t)next.frame + i; }
+      env->propSetIntArray(props, PROP_TDecimateCycleFrameNumsNext, next.diffMetricsF, next.length);
+      env->propSetFloatArray(props, PROP_TDecimateCycleMetricsNext, next.diffMetricsN, next.length);
   }
   return dst;
 }

--- a/src/TIVTC/TDecimate.cpp
+++ b/src/TIVTC/TDecimate.cpp
@@ -50,6 +50,19 @@ PVideoFrame __stdcall TDecimate::GetFrame(int n, IScriptEnvironment *env)
     else
       restoreHint<uint16_t>(dst, env);
   }
+  // Add frame properties: cycle metrics, frame numbers
+  if (has_at_least_v8) {
+      if (has_at_least_v9)
+          env->MakePropertyWritable(&dst);
+      else
+          env->MakeWritable(&dst);     
+      AVSMap* props = env->getFramePropsRW(dst); 
+ 
+      if (curr.diffMetricsF == nullptr) { curr.diffMetricsF = (int64_t*)malloc(curr.length * sizeof(int64_t)); }
+      for (int i = 0; i < curr.length; ++i) { curr.diffMetricsF[i] = (int64_t)curr.frame + i; }
+      env->propSetIntArray(props, PROP_TDecimateCycleFrameNums, curr.diffMetricsF, curr.length);
+      env->propSetFloatArray(props, PROP_TDecimateCycleMetrics, curr.diffMetricsN, curr.length);
+  }
   return dst;
 }
 

--- a/src/TIVTC/TDecimate.cpp
+++ b/src/TIVTC/TDecimate.cpp
@@ -1507,7 +1507,7 @@ bool TDecimate::checkForTwoDropLongestString(Cycle &p, Cycle &c, Cycle &n)
     (c1 != c.cycleS && (c.dupArray[c1 - 1] == 1 || c.dupArray[c1 + 1] == 1))) return false;
   if ((c2 == c.cycleE - 1 && (n.dupArray[n.cycleS] == 1 || c.dupArray[c2 - 1] == 1)) ||
     (c2 != c.cycleE - 1 && (c.dupArray[c2 - 1] == 1 || c.dupArray[c2 + 1] == 1))) return false;
-  if (hybrid == 0 && noblend)
+  if ((hybrid == 0 || hybrid == 1) && noblend) // allow noblend when hybrid=1
   {
     if (c.diffMetricsU[c1] <= c.diffMetricsU[c2])
       c.decimate[c1] = c.decimate2[c1] = 1;
@@ -1642,7 +1642,7 @@ void TDecimate::mostSimilarDecDecision(Cycle &p, Cycle &c, Cycle &n, IScriptEnvi
       if (savedc1 != c.lowest[0] && savedc1 != c.lowest[1]) goto tryother;
       if (savedc2 != c.lowest[0] && savedc2 != c.lowest[1]) goto tryother;
       if (abs(savedc1 - savedc2) <= 1) goto tryother;
-      if (hybrid == 0 && noblend)
+      if ((hybrid == 0 || hybrid == 1) && noblend) //allow noblend when hybrid=1
       {
         if (c.diffMetricsU[savedc1] <= c.diffMetricsU[savedc2])
           c.decimate[savedc1] = c.decimate2[savedc1] = 1;
@@ -1790,7 +1790,7 @@ void TDecimate::findDupStrings(Cycle &p, Cycle &c, Cycle &n, IScriptEnvironment 
       }
       if (n1 == c2) usecp += 5;
     }
-    if (hybrid == 0 && noblend && usecp == 6)
+    if ((hybrid == 0 || hybrid == 1) && noblend && usecp == 6) //allow noblend when hybrid=1
     {
       if (ct1 && !ct2) usecp = 5;
       else if (!ct1 && ct2) usecp = 1;
@@ -2356,6 +2356,11 @@ AVSValue __cdecl Create_TDecimate(AVSValue args, void* user_data, IScriptEnviron
   if ((mode == 0 || mode == 1 || mode == 3) && cycle > 1 && cycle < 26 && !(*input))
     v = new CacheFilter(args[0].AsClip(), cycle * 4 + 1, 1, cycle, env);
   else v = args[0].AsClip();
+
+  // backwards compatibility: retain default noblend behaviour when hybrid=1
+  // args[8]=hybrid , args[31]=noblend
+  bool noblend = args[8].AsInt(0) == 1 ? args[31].AsBool(false) : args[31].AsBool(true);
+  
   v = new TDecimate(v.AsClip(), args[1].AsInt(0), args[2].AsInt(1), args[3].AsInt(5),
     args[4].AsFloat(23.976f), args[5].AsFloat((float)dup_thresh), args[6].AsFloat((float)vid_thresh),
     args[7].AsFloat(15), args[8].AsInt(0), args[9].AsInt(vidDetect), args[10].AsInt(cc),
@@ -2363,7 +2368,7 @@ AVSValue __cdecl Create_TDecimate(AVSValue args, void* user_data, IScriptEnviron
     args[15].AsString(""), args[16].AsString(""), args[17].AsInt(0), args[18].AsInt(32), args[19].AsInt(32),
     args[20].AsBool(false), args[21].AsBool(false), args[22].AsInt(1), args[23].AsBool(false),
     args[24].AsBool(true), args[25].AsBool(false), chroma, args[27].AsBool(false),
-    args[28].AsInt(-200), args[29].AsBool(false), args[30].AsBool(false), args[31].AsBool(true),
+    args[28].AsInt(-200), args[29].AsBool(false), args[30].AsBool(false), noblend,
     args[32].AsBool(false), args[33].IsBool() ? (args[33].AsBool() ? 1 : 0) : -1,
     args[34].IsClip() ? args[34].AsClip() : NULL, args[35].AsInt(0), args[36].AsInt(4), args[37].AsString(""), 
     args[38].AsInt(0), args[39].AsInt(-1), // displayDecimation, displayOpt

--- a/src/common/internal.h
+++ b/src/common/internal.h
@@ -95,6 +95,8 @@ void BitBlt(uint8_t* dstp, int dst_pitch, const uint8_t* srcp, int src_pitch, in
 
 // Frame properties set by TDecimate:
 // #define PROP_TDecimateDisplay "TDecimateDisplay"
+#define PROP_TDecimateCycleMetrics "TDecimateCycleMetrics"
+#define PROP_TDecimateCycleFrameNums "TDecimateCycleFrameNums" 
 #define PROP_TDecimateCycleStart "TDecimateCycleStart"
 #define PROP_TDecimateCycleMaxBlockDiff "TDecimateCycleMaxBlockDiff" // uint64_t[]
 #define PROP_TDecimateOriginalFrame "TDecimateOriginalFrame"

--- a/src/common/internal.h
+++ b/src/common/internal.h
@@ -96,6 +96,8 @@ void BitBlt(uint8_t* dstp, int dst_pitch, const uint8_t* srcp, int src_pitch, in
 // Frame properties set by TDecimate:
 // #define PROP_TDecimateDisplay "TDecimateDisplay"
 #define PROP_TDecimateCycleMetrics "TDecimateCycleMetrics"
+#define PROP_TDecimateCycleMetricsPrev "TDecimateCycleMetricsPrev"
+#define PROP_TDecimateCycleMetricsNext "TDecimateCycleMetricsNext"
 #define PROP_TDecimateCycleFrameNums "TDecimateCycleFrameNums" 
 #define PROP_TDecimateCycleStart "TDecimateCycleStart"
 #define PROP_TDecimateCycleMaxBlockDiff "TDecimateCycleMaxBlockDiff" // uint64_t[]

--- a/src/common/internal.h
+++ b/src/common/internal.h
@@ -99,6 +99,8 @@ void BitBlt(uint8_t* dstp, int dst_pitch, const uint8_t* srcp, int src_pitch, in
 #define PROP_TDecimateCycleMetricsPrev "TDecimateCycleMetricsPrev"
 #define PROP_TDecimateCycleMetricsNext "TDecimateCycleMetricsNext"
 #define PROP_TDecimateCycleFrameNums "TDecimateCycleFrameNums" 
+#define PROP_TDecimateCycleFrameNumsPrev "TDecimateCycleFrameNumsPrev"
+#define PROP_TDecimateCycleFrameNumsNext "TDecimateCycleFrameNumsNext"
 #define PROP_TDecimateCycleStart "TDecimateCycleStart"
 #define PROP_TDecimateCycleMaxBlockDiff "TDecimateCycleMaxBlockDiff" // uint64_t[]
 #define PROP_TDecimateOriginalFrame "TDecimateOriginalFrame"

--- a/src/common/internal.h
+++ b/src/common/internal.h
@@ -101,6 +101,7 @@ void BitBlt(uint8_t* dstp, int dst_pitch, const uint8_t* srcp, int src_pitch, in
 #define PROP_TDecimateCycleFrameNums "TDecimateCycleFrameNums" 
 #define PROP_TDecimateCycleFrameNumsPrev "TDecimateCycleFrameNumsPrev"
 #define PROP_TDecimateCycleFrameNumsNext "TDecimateCycleFrameNumsNext"
+#define PROP_TDecimateCycleBlendStatus "TDecimateCycleBlendStatus"
 #define PROP_TDecimateCycleStart "TDecimateCycleStart"
 #define PROP_TDecimateCycleMaxBlockDiff "TDecimateCycleMaxBlockDiff" // uint64_t[]
 #define PROP_TDecimateOriginalFrame "TDecimateOriginalFrame"


### PR DESCRIPTION
I wanted to access TDecimate's cycle metrics in my .avsi script to see if there was more than 1 duplicate in the cycle as I wanted to tell if the duplicate resulted from an instantaneous field cadence break or whether the camera is just being held very still.  

Test script for the pull request:

```
# make some framediff metrics using audio histogram
ColorBars().ConvertToYV12().Histogram(mode="stereo").KillAudio().Trim(0,900)

# overlay TDecimate's metrics
TDecimate(display=true, cycle=5)  # try changing cycle as well to confirm PROPAPPENDMODE_APPEND behaviour

# overlay retrieved frame properties
ScriptClip("PrintProps(last, current_frame)", after_frame=true, local=false)

function PrintProps(clip c, int current_frame){
	
	metrics = propGetAsArray(c, "TDecimateCycleMetrics")
	string = "\n\n\n"
	
	for (i=0, ArraySize(metrics)-1){
		string = string + "         --> " + String(metrics[i], "%0.2f") + "\n" }
	
	c.Text(string, lsp=0, align=7, size=20, bold=true)
}
```

Yellow numbers are the props retrieved in Avisynth and should match the numbers in white

![debug avs_snapshot_00 00 000](https://github.com/pinterf/TIVTC/assets/46382337/e80ad43c-3b9a-4eea-a933-1a007261026f)
