### PR TITLE
Allow hybrid=1 scenechange decimation strategy when hybrid=0

### DIFF
--- a/Doc_TIVTC/TDecimate - READ ME.txt
+++ b/Doc_TIVTC/TDecimate - READ ME.txt
@@ -277,6 +277,19 @@ C.)  ADVANCED PARAMETERS:
         Default:  15  (float)
 
 
+    sceneDec -
+
+        Sets the decimation strategy around scene changes when mode=0 and hybrid=0.
+        When set to true, if the current cycle contains a scenechange frame, and the current cycle
+        is video (eg. 30p) then the frame before the scene change frame will be decimated instead
+        of the most similar frame in the cycle.  This can help avoid stutters around scene changes
+        due to field cadence breaks in the source.  The sensitivity to scene changes can be controlled
+        with sceneThresh.  This setting doesn't need to be enabled when hybrid=1 as it is already
+        part of the default hybrid=1 behaviour.
+		
+        Default:  false  (bool)
+
+
     vidDetect -
 
         This sets what is required for single cycle video detection when hybrid > 0. Whether

--- a/src/TIVTC/PluginInit.cpp
+++ b/src/TIVTC/PluginInit.cpp
@@ -62,7 +62,7 @@ AvisynthPluginInit3(IScriptEnvironment* env, const AVS_Linkage* const vectors) {
     "[ovr]s[output]s[input]s[tfmIn]s[mkvOut]s[nt]i[blockx]i" \
     "[blocky]i[debug]b[display]b[vfrDec]i[batch]b[tcfv1]b[se]b" \
     "[chroma]b[exPP]b[maxndl]i[m2PA]b[denoise]b[noblend]b[ssd]b" \
-    "[hint]b[clip2]c[sdlim]i[opt]i[orgOut]s[displayDecimation]i[displayOpt]i", Create_TDecimate, 0);
+    "[hint]b[clip2]c[sdlim]i[opt]i[orgOut]s[displayDecimation]i[displayOpt]i[sceneDec]b", Create_TDecimate, 0);
   env->AddFunction("MergeHints", "c[hintClip]c[debug]b", Create_MergeHints, 0);
   env->AddFunction("FieldDiff", "c[nt]i[chroma]b[display]b[debug]b[sse]b[opt]i",
     Create_FieldDiff, 0);

--- a/src/TIVTC/TDecimate.cpp
+++ b/src/TIVTC/TDecimate.cpp
@@ -203,7 +203,29 @@ PVideoFrame TDecimate::GetFrameMode01(int n, IScriptEnvironment* env, const Vide
     novidjump:
       if (mode == 0)
       {
-        mostSimilarDecDecision(prev, curr, next, env);
+       if (!sceneDec) { mostSimilarDecDecision(prev, curr, next, env); }   // retain backwards compatibility 
+        else {
+
+            bool decimateSceneNeighbour = false;
+            
+            checkVideoMetrics(curr, vidThresh);
+
+            if (curr.type == 3) {   // if cycle is video by metrics
+
+                int scenePosition = curr.sceneDetect(prev, next, sceneThreshU);
+
+                if (scenePosition != -20)  // -20 = no scenechange frame in cycle
+                {
+                    for (int p = curr.cycleS; p < curr.cycleE; ++p) curr.decimate[p] = curr.decimate2[p] = 0;
+                    curr.decimate[scenePosition] = curr.decimate2[scenePosition] = 1;
+                    curr.decSet = true;
+                    decimateSceneNeighbour = true;
+                }
+            }
+
+            // if we didn't decimate a scene neighbour, use normal decimation strategy
+            if (!decimateSceneNeighbour) { mostSimilarDecDecision(prev, curr, next, env); }
+        }
       }
       else
       {

--- a/src/TIVTC/TDecimate.cpp
+++ b/src/TIVTC/TDecimate.cpp
@@ -2393,7 +2393,7 @@ AVSValue __cdecl Create_TDecimate(AVSValue args, void* user_data, IScriptEnviron
     args[28].AsInt(-200), args[29].AsBool(false), args[30].AsBool(false), noblend,
     args[32].AsBool(false), args[33].IsBool() ? (args[33].AsBool() ? 1 : 0) : -1,
     args[34].IsClip() ? args[34].AsClip() : NULL, args[35].AsInt(0), args[36].AsInt(4), args[37].AsString(""), 
-    args[38].AsInt(0), args[39].AsInt(-1), // displayDecimation, displayOpt
+    args[38].AsInt(0), args[39].AsInt(-1), args[40].AsBool(false),  // arg[40] = sceneDec, defaults to false for backwards compatibility
     env);
   return v;
 }

--- a/src/TIVTC/TDecimate.cpp
+++ b/src/TIVTC/TDecimate.cpp
@@ -2728,7 +2728,7 @@ TDecimate::TDecimate(PClip _child, int _mode, int _cycleR, int _cycle, double _r
   int _nt, int _blockx, int _blocky, bool _debug, bool _display, int _vfrDec,
   bool _batch, bool _tcfv1, bool _se, bool _chroma, bool _exPP, int _maxndl, bool _m2PA,
   bool _predenoise, bool _noblend, bool _ssd, int _usehints, PClip _clip2,
-  int _sdlim, int _opt, const char* _orgOut, int _displayDecimation, int _displayOpt, IScriptEnvironment* env) : GenericVideoFilter(_child),
+  int _sdlim, int _opt, const char* _orgOut, int _displayDecimation, int _displayOpt, bool _sceneDec, IScriptEnvironment* env) : GenericVideoFilter(_child),
   mode(_mode),
   cycleR(_cycleR), cycle(_cycle), rate(_rate), dupThresh(_dupThresh),
   hybrid(_hybrid), vidThresh(_vidThresh),
@@ -2738,7 +2738,7 @@ TDecimate::TDecimate(PClip _child, int _mode, int _cycleR, int _cycle, double _r
   vfrDec(_vfrDec), debug(_debug), display(_display), batch(_batch), tcfv1(_tcfv1), se(_se),
   maxndl(_maxndl), chroma(_chroma), m2PA(_m2PA), exPP(_exPP),
   noblend(_noblend), predenoise(_predenoise), ssd(_ssd), sdlim(_sdlim),
-  opt(_opt), clip2(_clip2), orgOut(_orgOut), displayDecimation(_displayDecimation), displayOpt(_displayOpt),
+  opt(_opt), clip2(_clip2), orgOut(_orgOut), displayDecimation(_displayDecimation), displayOpt(_displayOpt), sceneDec(_sceneDec),  
   prev(5, 0), curr(5, 0), next(5, 0), nbuf(5, 0), diff(nullptr, nullptr)
 {
 

--- a/src/TIVTC/TDecimate.h
+++ b/src/TIVTC/TDecimate.h
@@ -91,6 +91,7 @@ private:
   int conCycleTP;
   int vidDetect;
   double sceneThresh;
+  bool sceneDec; 
   int conCycle;
   std::string ovr;
   std::string input;
@@ -219,7 +220,7 @@ public:
     int _nt, int _blockx, int _blocky, bool _debug, bool _display, int _vfrDec,
     bool _batch, bool _tcfv1, bool _se, bool _chroma, bool _exPP, int _maxndl,
     bool _m2PA, bool _predenoise, bool _noblend, bool _ssd, int _usehints,
-    PClip _clip2, int _sdlim, int _opt, const char* _orgOut, int _displayDecimation, int _displayOpt, IScriptEnvironment* env);
+    PClip _clip2, int _sdlim, int _opt, const char* _orgOut, int _displayDecimation, int _displayOpt, bool _sceneDec, IScriptEnvironment* env);
   ~TDecimate();
 
   int __stdcall SetCacheHints(int cachehints, int frame_range) override {

--- a/src/TIVTC/TDecimateOut.cpp
+++ b/src/TIVTC/TDecimateOut.cpp
@@ -339,6 +339,8 @@ void TDecimate::displayOutput(IScriptEnvironment* env, PVideoFrame &dst, int n,
   // display top with extra statistics for displayDecimationDefined case
   if (!displayDecimationDefined)
     sprintf(buf, "Mode: %d  Cycle: %d  CycleR: %d  Hybrid: %d", mode, cycle, cycleR, hybrid);
+    // confirm sceneDec is set correctly for backwards compatibility
+    // sprintf(buf, "Mode: %d  Cycle: %d  CycleR: %d  Hybrid: %d sceneDec: %d", mode, cycle, cycleR, hybrid, sceneDec);
   else
     sprintf(buf, "Mode: %d  Cycle: %d  CycleR: %d  Hybrid: %d  #ofDecimations: %d (%d:%d)", mode, cycle, cycleR, hybrid, 
       num_of_decimations_in_display, num_of_decimations_till_display_end, cycleR - num_of_decimations_till_display_end);


### PR DESCRIPTION
The hybrid=1 mode has a neat feature where if it detects a single isolated cycle of video frames (eg. 30p) and the cycle contains a scenechange frame, then it decimates the frame adjacent to the scenechange instead of the one with the lowest diff in the cycle.  This can help avoid stutters around scenechanges due to field cadence breaks in the source, so I wanted to allow this behaviour for the hybrid=0 mode as well.

The implementation defaults to original behaviour to keep backwards compatibility with previous scripts.  The new behaviour only comes into effect if the user manually enables it with `sceneDec=true` and only when mode=0.

![example1](https://github.com/pinterf/TIVTC/assets/46382337/08686396-8e51-456b-941c-c745b9ca1079)

Demo video (prerendered): https://drive.google.com/uc?export=download&id=1UK68kcE20CXu8MfRR5DnUALvp9fooKJl
You'll have to keep your eye on Jerry O'Connell's face right before the scenechange to see it.

Test script to reproduce

```
LWLibavVideoSource("C:\clip1.mkv", repeat=true) 
# clip1.mkv: https://drive.google.com/uc?export=download&id=1LMlovnns_UtfVS25RnIkEuRGZVFop0lS
# sorry for the file size but if I shorten it with ffmpeg it offsets the position of the cadence break

tfm = TFM(slow=2, pp=0, hint=false).Trim(12640,12760) 

left = tfm
\ .TDecimate(sceneDec=false, chroma=false, denoise=true, hint=false, display=true)
\ .Spline36Resize(720,540)

right = tfm
\ .TDecimate(sceneDec=true, chroma=false, denoise=true, hint=false, display=true)
\ .Spline36Resize(720,540)

StackHorizontal(left, right)
Loop(5)
```

Another example to try and visualise it more clearly, here the cadence break is created manually with DeleteFrame()

```
LWLibavVideoSource("C:\clip2.mkv", repeat=true) 
# clip2.mkv: https://drive.google.com/uc?export=download&id=1HdaoJiagh_meHmaC4zoMGC1mfhykc_8r

tfm = TFM(slow=2, pp=0, hint=false).DeleteFrame(220, 226)

left = tfm
\ .TDecimate(chroma=false, denoise=true, hint=false, sceneDec=false, display=true)
\ .Spline36Resize(720,540) 

right = tfm
\ .TDecimate(chroma=false, denoise=true, hint=false, sceneDec=true, display=true)
\ .Spline36Resize(720,540)

StackHorizontal(left, right).Trim(120, 220)
Loop(5)

```

Note that cadence breaks in the source can also cause duplicate frames around scenechanges, and this feature doesn't get rid of those.   Those duplicates can be blended over by doing a second pass of TDecimate in hybrid=3 mode and controlling false positives with a ScriptClip to look at the cycle metrics via the new frame properties.
