### PR TITLE
Fix: change bytes size

### DIFF
--- a/src/TIVTC/TDecimateOut.cpp
+++ b/src/TIVTC/TDecimateOut.cpp
@@ -190,7 +190,7 @@ void TDecimate::displayOutput(IScriptEnvironment* env, PVideoFrame &dst, int n,
   int ret, bool film, double amount1, double amount2, int f1, int f2, const VideoInfo &vi_disp)
 {
   int y = 0;
-  char tempBuf[40];
+  char tempBuf[60];
   sprintf(buf, "TDecimate %s by tritical", VERSION);
 
   constexpr auto FONT_WIDTH = 10; // info_h


### PR DESCRIPTION
```
TDecimateOut.cpp:221:51: warning: '%d' directive writing between 1 and 11 bytes into a region of size between 0 and 14 -Wformat-overflow=]
  221 |     sprintf(tempBuf, "  displayDecimation: %d (%d-%d)", displayDecimation, displayFrom, displayTo);
      |                                                   ^~
TDecimateOut.cpp:221:22: note: directive argument in the range [-2147483648, 2147483646]
  221 |     sprintf(tempBuf, "  displayDecimation: %d (%d-%d)", displayDecimation, displayFrom, displayTo);
      |                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
TDecimateOut.cpp:221:12: note: 'sprintf' output between 29 and 58 bytes into a destination of size 40
  221 |     sprintf(tempBuf, "  displayDecimation: %d (%d-%d)", displayDecimation, displayFrom, displayTo);
      |     ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```