### PR TITLE
Add diagonal combing detection

### DIFF
--- a/src/common/TCommonASM.cpp
+++ b/src/common/TCommonASM.cpp
@@ -897,9 +897,26 @@ void check_combing_c_Metric1(const pixel_t* srcp, uint8_t* cmkp, int width, int 
 
   for (int y = 0; y < height; ++y)
   {
-    for (int x = 0; x < width; x += increment)
+    // Do first and last line
+    if ((safeint_t)(srcp[0] - srcpp[0]) * (srcp[0] - srcpn[0]) > cthreshsq)
+      cmkp[0] = 0xFF;
+    if ((safeint_t)(srcp[width - 1] - srcpp[width - 1]) * (srcp[width - 1] - srcpn[width - 1]) > cthreshsq)
+      cmkp[width - 1] = 0xFF;
+
+    for (int x = 1; x < width-1; x += increment)
     {
+      // Vertical combing check
       if ((safeint_t)(srcp[x] - srcpp[x]) * (srcp[x] - srcpn[x]) > cthreshsq)
+        cmkp[x] = 0xFF;
+
+      // Skip diagonals if vertical lines suspected
+      if((srcp[x] - srcp[x+increment])*(srcp[x] - srcp[x-increment]) > cthreshsq)
+        continue;
+
+      // Additional diagonal combing checks
+      if ((safeint_t)(srcp[x] - srcpp[x+increment]) * (srcp[x] - srcpn[x-increment]) > cthreshsq)
+        cmkp[x] = 0xFF;
+      if ((safeint_t)(srcp[x] - srcpp[x-increment]) * (srcp[x] - srcpn[x+increment]) > cthreshsq)
         cmkp[x] = 0xFF;
     }
     srcpp += src_pitch;


### PR DESCRIPTION
This PR modifies the combing detection algorithm `metric=1` to better detect combing along diagonal lines. Since the algorithm detects extra pixels as combed (in addition to those detected by the base algorithm), the MI value must be increased to compensate.

Currently there's only the C implementation. If the changes are deemed worthy, we can discuss the SSE2 implementation.

Here are some screenshots for comparison, produced by:

```c
left=FFVideoSource(FileName).TFM(pp=1, metric=1, opt=0, MI=85, display=true).TDecimate()
right=FFVideoSource(FileName).TFM(pp=7, metric=1, opt=0, MI=85).TDecimate()
StackHorizontal(left, right)
```

This PR, clean frame correctly detected
<img width="1440" height="480" alt="compare new2_03 59 994" src="https://github.com/user-attachments/assets/b2394dd3-9f47-40b9-9b05-21ec7bfa4264" />

This PR, combed frame correctly detected
<img width="1440" height="480" alt="compare new2_05 47 807" src="https://github.com/user-attachments/assets/afba7eb1-2566-4fc5-9a6e-8c5f7f5526a0" />

This PR, combed frame correctly detected
<img width="1440" height="480" alt="compare new2_05 48 753" src="https://github.com/user-attachments/assets/10db8707-daac-49bb-b713-4bfda7125ba4" />

Base algorithm, clean frame detected as combed
<img width="1440" height="480" alt="compare old_03 59 964" src="https://github.com/user-attachments/assets/53dd1c74-1d36-46a2-ac1a-86f692a7fa56" />

Base algorithm, combed frame not detected
<img width="1440" height="480" alt="compare old_05 47 813" src="https://github.com/user-attachments/assets/9b0e1268-a1db-435c-a7f7-644eb407fc37" />

Base algorithm, combed frame not detected
<img width="1440" height="480" alt="compare old_05 48 766" src="https://github.com/user-attachments/assets/8984b8bf-a51b-4097-9733-f188fe4e5632" />
